### PR TITLE
Fix Bootstrap Properties Priority

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,7 @@ function readConfig(options) {
 		readYamlAsDocument(theBootstrapPath + '/bootstrap.yml', options.activeProfiles).then((thisBootstrapConfig) => {
 			thisBootstrapConfig.profiles = options.activeProfiles;
 			logger.debug("Using Bootstrap Config: " + JSON.stringify(thisBootstrapConfig));
-			bootstrapConfig = thisBootstrapConfig
-			propertiesObjects.push(thisBootstrapConfig);
+			bootstrapConfig = thisBootstrapConfig;
 			
 			return readApplicationConfig(options.configPath, options.activeProfiles);
 		}).then((applicationConfig) => {
@@ -39,6 +38,8 @@ function readConfig(options) {
 			return readCloudConfig(bootstrapConfig);
 		}).then((cloudConfig) => {
 			propertiesObjects.push(cloudConfig);
+			// Bootstrap properties have the highest priority
+			propertiesObjects.push(bootstrapConfig);
 			// Merge the properties into a single object
 			instance = mergeProperties(propertiesObjects);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spring-cloud-config",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "NodeJS configuration management library based on Spring Cloud Config.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
The properties defined in bootstrap.yml should have the highest priority and should not be overridden by properties in application.yml.