### PR TITLE
Bootstrap config isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Feature requests are welcome.
 
 ## Introduction
 
-You get to define your application properties the same way you do in your Spring Boot applications. Use a `bootstrap.yml` file to specify your config server settings and `application.yml` to hold your local application properties. This module even supports profiling, similar to Spring Boot profiles, giving you the option to define profile-based properties in either separate files (like `application-{profile}.yml`) or in a single multi-document yaml file using a `profiles: profile1,profile2` property format on the applicable documents.
+You get to define your application properties the same way you do in your Spring Boot applications. Use a `bootstrap.yml` file to specify your config server settings and `application.yml` to hold your local application properties. This module even supports profiling, similar to Spring Boot profiles, giving you the option to define profile-based properties in either separate files, like `application-{profile}.yml`, or in a single multi-document yaml file using a `profiles` property on the applicable documents, like `profiles: profile1,profile2`.
 
 ## Getting Started
 
@@ -21,29 +21,32 @@ Install the package
 npm install spring-cloud-config
 ```
 
-Define an application.yml in the location of your choice.
+Define an application.yml, or a group of application.yml and application-{profile}.yml files, in the location of your choice.
 #### application.yml
 ```yaml
-name: my-application-name
+spring.cloud.config.name: my-application-name
 db:
-    mongo:
-        url: http://localhost:27017
+   mongo:
+      url: http://localhost:27017
 ---
 profiles: dev1,dev2
 db:
-    mongo:
-        url: http://dev-mongo-server:27017
+   mongo:
+      url: http://dev-mongo-server:27017
 ```
 
 Define a bootstrap.yml in the location of your choice.
 #### bootstrap.yml
 ```yaml
-spring.cloud.config.enabled: true
-endpoint: http://localhost:8888
-label: master
+spring:
+   cloud:
+      config:
+         enabled: true
+         endpoint: http://localhost:8888
+         label: master
 ---
 profiles: dev1,dev2
-endpoint: http://dev-config-server:8888
+spring.cloud.config.endpoint: http://dev-config-server:8888
 ```
 
 Consume the module in your script.
@@ -63,23 +66,23 @@ let myMongoUrl = myConfig.db.mongo.url;
 
 ### The Yaml Files
 
-As mentioned above, this module uses Yaml files to configure your application properties. You need to supply folder paths where it can expect to find two sets of files: `bootstrap.yml` and `application.yml`. The bootstrap yaml is used to configure your cloud config server properties, similar to Spring Cloud Config. The application yaml should be used for defining your application's configuration properties. Optionally, you can specify your application's name in application.yml instead of in bootstrap.yml, using the `name` property. Doing so gives you the option of using a shared bootstrap.yml (i.e. shared with other apps) but still be able to specify your individual application's name.
+As mentioned above, this module uses Yaml files to configure your application properties. You need to supply folder paths where it can expect to find two sets of files: `bootstrap.yml` and `application.yml`. The bootstrap yaml is used to configure your cloud config server properties, similar to Spring Cloud Config. The application yaml should be used for defining your application's configuration properties. Optionally, you can specify your application's name in application.yml instead of in bootstrap.yml, using the `spring.cloud.config.name` property. Doing so gives you the option of using a shared bootstrap.yml (i.e. shared with other apps) but still be able to specify your individual application's name.
 
 ### Support for Profiles in Multi-Document Yaml
 
-As with any Yaml implementation, you can include multiple documents in each Yaml file using `---` as a separator. Additionally, this module allows you to define documents that apply to specific 'profiles', same as the 'spring.profiles' concept. If you include a `profiles:` property in a given yaml document, the properties in that document will only be included in your merged configuration result if any of the `configOptions.activeProfiles` match up with the specified profiles.
+As with any Yaml implementation, you can include multiple documents in each Yaml file using `---` as a separator. Additionally, this module allows you to define documents that apply to specific 'profiles', same as the 'spring.profiles' concept. If you include a `profiles` property in a given yaml document, the properties in that document will only be included in your merged configuration result if any of the `configOptions.activeProfiles` match up with the specified profiles.
 
 #### Example application.yml
 ```yaml
-name: my-application-name
+spring.cloud.config.name: my-application-name
 db:
-    mongo:
-        url: http://localhost:27017
+   mongo:
+      url: http://localhost:27017
 ---
 profiles: dev1,dev2,!local
 db:
-    mongo:
-        url: http://dev-mongo-server:27017
+   mongo:
+      url: http://dev-mongo-server:27017
 ```
 
 #### Applying Yaml Docs to Multiple Profiles
@@ -88,7 +91,7 @@ You can apply the properties of a Yaml doc to multiple application profiles. Jus
 
 #### Excluding Yaml Docs from Profiles
 
-This module supports the `Not` operator (!) on profiles to provide for excluding configuration properties from specific profiles. Just prepend a '!' to the profile name you want to exclude the given yaml doc from, like `profiles: dev1,!dev2`.
+This module supports the `Not` operator (!) on profiles to provide for excluding configuration properties from specific profiles. Just prepend an '!' to the profile name you want to exclude the given yaml doc from, like `profiles: dev1,!dev2`.
 
 ### Support for Profile-Specific File Names
 
@@ -127,18 +130,19 @@ Returns the current configuration properties object. Use the `load` function pri
 ### `bootstrap.yml` Cloud Config Options
 Option | Type | Description
 ------ | -------- | -----------
+spring.cloud.config | Object | The config options to use for fetching remote properties from a Spring Cloud Config Server.
 spring.cloud.config.enabled | boolean | Enable/disable the usage of remote properties via a Spring Cloud Config Server.
 Properties Inherited from [cloud-config-client](https://www.npmjs.com/package/cloud-config-client) | | 
-name | String | Optional - The application name to be used for reading remote properties. Alternatively, if not provided here, this must be specified in your application.yml.
-endpoint | String | The url endpoint of the Spring Cloud Config Server.
-label | String | The cloud config label to use.
-rejectUnauthorized | boolean | default = true: if false accepts self-signed certificates
-auth | Object | optional: Basic Authentication for config server (e.g.: { user: "username", pass: "password"}). endpoint accepts also basic auth (e.g. http://user:pass@localhost:8888).
-auth.user | string | mandatory username if using auth
-auth.pass | string | mandatory password if using auth
+spring.cloud.config.name | String | Optional - The application name to be used for reading remote properties. Alternatively, if not provided here, this must be specified in your application.yml.
+spring.cloud.config.endpoint | String | The url endpoint of the Spring Cloud Config Server.
+spring.cloud.config.label | String | The cloud config label to use.
+spring.cloud.config.rejectUnauthorized | boolean | default = true: if false accepts self-signed certificates
+spring.cloud.config.auth | Object | optional: Basic Authentication for config server (e.g.: { user: "username", pass: "password"}). endpoint accepts also basic auth (e.g. http://user:pass@localhost:8888).
+spring.cloud.config.auth.user | string | mandatory username if using auth
+spring.cloud.config.auth.pass | string | mandatory password if using auth
 
 ### `application.yml` Application Config Properties
 Option | Type | Description
 ------ | -------- | -----------
-name | String | Optional - You can override/specify your application name here, or in bootstrap.yml. This is an option so that you can share bootstrap.yml with other applications, but use your own application name.
+spring.cloud.config.name | String | Optional - You can override/specify your application name here, or in bootstrap.yml. This is an option so that you can share bootstrap.yml with other applications but still use your own application name.
 any.property.you.need | ? | This is your playground where you define whatever properties your application needs to function.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ auth | Object | optional: Basic Authentication for config server (e.g.: { user: 
 auth.user | string | mandatory username if using auth
 auth.pass | string | mandatory password if using auth
 
-## `application.yml` Application Config Properties
+### `application.yml` Application Config Properties
 Option | Type | Description
 ------ | -------- | -----------
 name | String | Optional - You can override/specify your application name here, or in bootstrap.yml. This is an option so that you can share bootstrap.yml with other applications, but use your own application name.

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function readConfig(options) {
 		// Load bootstrap.yml based on the profile name (like devEast or stagingEast)
 		let theBootstrapPath = options.bootstrapPath ? options.bootstrapPath : options.configPath;
 		readYamlAsDocument(theBootstrapPath + '/bootstrap.yml', options.activeProfiles).then((thisBootstrapConfig) => {
-			thisBootstrapConfig.profiles = options.activeProfiles;
+			thisBootstrapConfig.spring.cloud.config.profiles = options.activeProfiles;
 			logger.debug("Using Bootstrap Config: " + JSON.stringify(thisBootstrapConfig));
 			bootstrapConfig = thisBootstrapConfig;
 			
@@ -32,8 +32,11 @@ function readConfig(options) {
 		}).then((applicationConfig) => {
 			logger.debug("Using Application Config: " + JSON.stringify(applicationConfig));
 			propertiesObjects.push(applicationConfig);
-			if (applicationConfig.name)
-				bootstrapConfig.name = applicationConfig.name;
+			if (applicationConfig.spring 
+					&& applicationConfig.spring.cloud 
+					&& applicationConfig.spring.cloud.config 
+					&& applicationConfig.spring.cloud.config.name)
+				bootstrapConfig.spring.cloud.config.name = applicationConfig.spring.cloud.config.name;
 			
 			return readCloudConfig(bootstrapConfig);
 		}).then((cloudConfig) => {
@@ -94,8 +97,8 @@ function readCloudConfig(bootStrapConfig) {
 		var cloudConfig = {};
 		if (bootStrapConfig.spring.cloud.config.enabled) {
 			try {
-				logger.debug("Cloud Options: " + JSON.stringify(bootStrapConfig));
-				cloudConfigClient.load(bootStrapConfig).then((cloudConfigProperties) => {
+				logger.debug("Spring Cloud Options: " + JSON.stringify(bootStrapConfig.spring.cloud.config));
+				cloudConfigClient.load(bootStrapConfig.spring.cloud.config).then((cloudConfigProperties) => {
 					if (cloudConfigProperties) {
 						cloudConfigProperties.forEach(function(key, value) {
 							cloudConfig[key] = value;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spring-cloud-config",
-  "version": "1.2.2",
-  "description": "NodeJS configuration management library based on Spring Cloud Config.",
+  "version": "2.0.0",
+  "description": "NodeJS application configuration using similar style to Spring Config and using the Spring Cloud Config Server for remote property sources.",
   "main": "index.js",
   "dependencies": {
     "cloud-config-client": "^0.3.1",

--- a/test/fixtures/load/appNameConfig/application.yml
+++ b/test/fixtures/load/appNameConfig/application.yml
@@ -1,1 +1,1 @@
-name: 'custom-app-name'
+spring.cloud.config.name: 'custom-app-name'

--- a/test/fixtures/load/commonConfig/bootstrap.yml
+++ b/test/fixtures/load/commonConfig/bootstrap.yml
@@ -1,8 +1,11 @@
 #Default config properties
-spring.cloud.config.enabled: true
-name: the-application-name
-endpoint: http://localhost:8888
-label: master
+spring:
+   cloud:
+      config:
+         enabled: true
+         name: the-application-name
+         endpoint: http://localhost:8888
+         label: master
 ---
 profiles: dev1,dev2
-endpoint: http://dev-config-server:8888
+spring.cloud.config.endpoint: http://dev-config-server:8888

--- a/test/fixtures/load/configSameFolder/bootstrap.yml
+++ b/test/fixtures/load/configSameFolder/bootstrap.yml
@@ -1,8 +1,11 @@
 #Default config properties
-spring.cloud.config.enabled: true
-name: the-application-name
-endpoint: http://localhost:8888
-label: master
+spring:
+   cloud:
+      config:
+         enabled: true
+         name: the-application-name
+         endpoint: http://localhost:8888
+         label: master
 ---
 profiles: dev1,dev2
-endpoint: http://dev-config-server:8888
+spring.cloud.config.endpoint: http://dev-config-server:8888

--- a/test/unit/config-test.js
+++ b/test/unit/config-test.js
@@ -264,9 +264,11 @@ describe('spring-cloud-config-client', function() {
 
 		it('should skip cloud config if unreachable', function() {
 			let bootstrapConfig = {
-				spring: {cloud: {config: {enabled: true}}},
-				name: 'the-application-name',
-				endpoint: 'http://localhost:8888'
+				spring: {cloud: {config: {
+					enabled: true,
+					name: 'the-application-name',
+					endpoint: 'http://localhost:8888'
+				}}},
 			};
 			return springCloudConfig.readCloudConfig(bootstrapConfig).then((config) => {
 				assert.deepEqual(config, {});
@@ -346,10 +348,10 @@ describe('spring-cloud-config-client', function() {
 				level: 'debug'
 			}
 			return springCloudConfig.load(options).then((config) => {
-				assert.deepEqual(config.name, 'the-application-name');
+				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
+				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://localhost:8888');
+				assert.deepEqual(config.spring.cloud.config.label, 'master');
 				assert.deepEqual(config.testUrl, 'http://www.default.com');
-				assert.deepEqual(config.endpoint, 'http://localhost:8888');
-				assert.deepEqual(config.label, 'master');
 			}, (error) => {
 				assert.fail("Error", "Success", JSON.stringify(error.message));
 			});
@@ -366,10 +368,10 @@ describe('spring-cloud-config-client', function() {
 				level: 'debug'
 			}
 			return springCloudConfig.load(options).then((config) => {
-				assert.deepEqual(config.name, 'the-application-name');
+				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
+				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://localhost:8888');
+				assert.deepEqual(config.spring.cloud.config.label, 'master');
 				assert.deepEqual(config.testUrl, 'http://www.default.com');
-				assert.deepEqual(config.endpoint, 'http://localhost:8888');
-				assert.deepEqual(config.label, 'master');
 			}, (error) => {
 				assert.fail("Error", "Success", JSON.stringify(error.message));
 			});
@@ -386,9 +388,9 @@ describe('spring-cloud-config-client', function() {
 				level: 'debug'
 			}
 			return springCloudConfig.load(options).then((config) => {
-				assert.deepEqual(config.name, 'custom-app-name');
-				assert.deepEqual(config.endpoint, 'http://localhost:8888');
-				assert.deepEqual(config.label, 'master');
+				assert.deepEqual(config.spring.cloud.config.name, 'custom-app-name');
+				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://localhost:8888');
+				assert.deepEqual(config.spring.cloud.config.label, 'master');
 			}, (error) => {
 				assert.fail("Error", "Success", JSON.stringify(error.message));
 			});
@@ -405,10 +407,10 @@ describe('spring-cloud-config-client', function() {
 				level: 'debug'
 			}
 			return springCloudConfig.load(options).then((config) => {
-				assert.deepEqual(config.name, 'the-application-name');
+				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
+				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://dev-config-server:8888');
+				assert.deepEqual(config.spring.cloud.config.label, 'master');
 				assert.deepEqual(config.testUrl, 'http://www.dev.com');
-				assert.deepEqual(config.endpoint, 'http://dev-config-server:8888');
-				assert.deepEqual(config.label, 'master');
 			}, (error) => {
 				assert.fail("Error", "Success", JSON.stringify(error.message));
 			});
@@ -431,10 +433,10 @@ describe('spring-cloud-config-client', function() {
 				level: 'debug'
 			}
 			return springCloudConfig.load(options).then((config) => {
-				assert.deepEqual(config.name, 'the-application-name');
+				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
+				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://localhost:8888');
+				assert.deepEqual(config.spring.cloud.config.label, 'master');
 				assert.deepEqual(config.testUrl, 'http://www.default-local.com');
-				assert.deepEqual(config.endpoint, 'http://localhost:8888');
-				assert.deepEqual(config.label, 'master');
 				assert.deepEqual(config.featureFlags.feature1, false);
 				assert.deepEqual(config.featureFlags.feature2, false);
 			}, (error) => {
@@ -459,10 +461,10 @@ describe('spring-cloud-config-client', function() {
 				level: 'debug'
 			}
 			return springCloudConfig.load(options).then((config) => {
-				assert.deepEqual(config.name, 'the-application-name');
+				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
+				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://dev-config-server:8888');
+				assert.deepEqual(config.spring.cloud.config.label, 'master');
 				assert.deepEqual(config.testUrl, 'http://www.dev-cloud.com');
-				assert.deepEqual(config.endpoint, 'http://dev-config-server:8888');
-				assert.deepEqual(config.label, 'master');
 				assert.deepEqual(config.featureFlags.feature1, true);
 				assert.deepEqual(config.featureFlags.feature2, false);
 			}, (error) => {
@@ -493,9 +495,9 @@ describe('spring-cloud-config-client', function() {
 			}
 			return springCloudConfig.load(options).then((config) => {
 				let theConfig = springCloudConfig.instance();
-				assert.deepEqual(theConfig.name, 'the-application-name');
+				assert.deepEqual(theConfig.spring.cloud.config.name, 'the-application-name');
+				assert.deepEqual(theConfig.spring.cloud.config.endpoint, 'http://localhost:8888');
 				assert.deepEqual(theConfig.testUrl, 'http://www.default.com');
-				assert.deepEqual(theConfig.endpoint, 'http://localhost:8888');
 			}, (error) => {
 				assert.fail("Error", "Success", JSON.stringify(error.message));
 			});


### PR DESCRIPTION
Resolves #10

Moved the spring cloud config properties in bootstrap.yml under a spring-specific property group to provide isolation from the application's properties. This is a breaking change so I'm upping the version to 2.0.0.