### PR TITLE
Add JOI Schemas, Update Tests, and Cleanup Library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - "node"
-  - "6"
+  - "10"
+  - "8"

--- a/README.md
+++ b/README.md
@@ -156,9 +156,11 @@ spring.cloud.config.rejectUnauthorized | boolean | default = true: if false acce
 spring.cloud.config.auth | Object | optional: Basic Authentication for config server (e.g.: { user: "username", pass: "password"}). endpoint accepts also basic auth (e.g. http://user:pass@localhost:8888).
 spring.cloud.config.auth.user | string | mandatory username if using auth
 spring.cloud.config.auth.pass | string | mandatory password if using auth
+profiles | string | Comma separated string of profiles. Indicates which profiles the properties in the current yaml document apply to.
 
 ### `application.yml` Application Config Properties
 Option | Type | Description
 ------ | -------- | -----------
 spring.cloud.config.name | String | Optional - You can override/specify your application name here, or in bootstrap.yml. This is an option so that you can share bootstrap.yml with other applications but still use your own application name.
+profiles | string | Comma separated string of profiles. Indicates which profiles the properties in the current yaml document apply to.
 any.property.you.need | ? | This is your playground where you define whatever properties your application needs to function.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spring-cloud-config",
-  "version": "3.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -122,6 +122,47 @@
         "to-fast-properties": "2.0.0"
       }
     },
+    "@hapi/address": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
+      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+    },
+    "@hapi/hoek": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+      "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+    },
+    "@hapi/joi": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
+      "integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
+      "requires": {
+        "@hapi/address": "2.0.0",
+        "@hapi/hoek": "6.2.4",
+        "@hapi/marker": "1.0.0",
+        "@hapi/topo": "3.1.2"
+      }
+    },
+    "@hapi/marker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
+      "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
+    },
+    "@hapi/topo": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz",
+      "integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
+      "requires": {
+        "@hapi/hoek": "8.0.1"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.0.1.tgz",
+          "integrity": "sha512-cctMYH5RLbElaUpZn3IJaUj9QNQD8iXDnl7xNY6KB1aFD2ciJrwpo3kvZowIT75uA+silJFDnSR2kGakALUymg=="
+        }
+      }
+    },
     "@istanbuljs/nyc-config-typescript": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-0.1.3.tgz",
@@ -169,6 +210,15 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
       "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
       "dev": true
+    },
+    "@types/chai-as-promised": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.0.tgz",
+      "integrity": "sha512-MFiW54UOSt+f2bRw8J7LgQeIvE/9b4oGvwU7XW30S9QGAiHGnU/fmiOprsyMkdmH2rl8xSPc0/yrQw8juXU6bQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "4.1.7"
+      }
     },
     "@types/mocha": {
       "version": "5.2.7",
@@ -345,6 +395,12 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+      "dev": true
+    },
     "camelcase": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
@@ -377,6 +433,15 @@
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
         "type-detect": "4.0.8"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "1.0.2"
       }
     },
     "chalk": {
@@ -543,6 +608,15 @@
       "dev": true,
       "requires": {
         "ms": "2.1.1"
+      }
+    },
+    "decache": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-4.5.1.tgz",
+      "integrity": "sha512-5J37nATc6FmOTLbcsr9qx7Nm28qQyg1SK4xyEHqM0IBkNhWFp0Sm+vKoWYHD8wq+OUEb9jLyaKFfzzd1A9hcoA==",
+      "dev": true,
+      "requires": {
+        "callsite": "1.0.0"
       }
     },
     "decamelize": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spring-cloud-config",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
+    "@hapi/joi": "^15.1.0",
     "cloud-config-client": "^1.0.0",
     "extend": "^3.0.2",
     "js-yaml": "^3.12.0",
@@ -15,11 +16,14 @@
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^0.1.3",
     "@types/chai": "4.1.7",
+    "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "5.2.7",
     "@types/node": "12.0.10",
     "@types/sinon": "7.0.13",
     "chai": "4.2.0",
+    "chai-as-promised": "^7.1.1",
     "coveralls": "3.0.4",
+    "decache": "^4.5.1",
     "jsdoc": "3.6.2",
     "mocha": "6.1.4",
     "mocha-lcov-reporter": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spring-cloud-config",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "NodeJS application configuration using similar style to Spring Config and using the Spring Cloud Config Server for remote property sources.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/SpringCloudConfig.ts
+++ b/src/SpringCloudConfig.ts
@@ -116,27 +116,22 @@ export const readApplicationConfig = async (appConfigPath: string, activeProfile
 export const readCloudConfig = async (bootStrapConfig: ConfigObject): Promise<ConfigObject> => {
 	let cloudConfig = {};
 	if (bootStrapConfig.spring.cloud.config.enabled) {
+		logger.debug("Spring Cloud Options: " + JSON.stringify(bootStrapConfig.spring.cloud.config));
 		try {
-			logger.debug("Spring Cloud Options: " + JSON.stringify(bootStrapConfig.spring.cloud.config));
-			try {
-				const cloudConfigProperties: ConfigObject = 
-					await cloudConfigClient.load(bootStrapConfig.spring.cloud.config, null);
-				if (cloudConfigProperties) {
-					cloudConfigProperties.forEach(function(key, value) {
-						cloudConfig[key] = value;
-					}, false);
-					cloudConfig = parsePropertiesToObjects(cloudConfig);
-				}
-				logger.debug("Cloud Config: " + JSON.stringify(cloudConfig));
-				return cloudConfig;
-			} catch (error) {
-				logger.error("Error reading cloud config: %s", error.message);
-				return cloudConfig;
-			};
-		} catch (e) {
-			logger.error("Caught error from cloud config client: %s", e.message);
+			const cloudConfigProperties: ConfigObject = 
+				await cloudConfigClient.load(bootStrapConfig.spring.cloud.config, null);
+			if (cloudConfigProperties) {
+				cloudConfigProperties.forEach(function(key, value) {
+					cloudConfig[key] = value;
+				}, false);
+				cloudConfig = parsePropertiesToObjects(cloudConfig);
+			}
+			logger.debug("Cloud Config: " + JSON.stringify(cloudConfig));
 			return cloudConfig;
-		}
+		} catch (error) {
+			logger.error("Error reading cloud config: %s", error.message);
+			return cloudConfig;
+		};
 	} else {
 		return cloudConfig;
 	}

--- a/src/SpringCloudConfig.ts
+++ b/src/SpringCloudConfig.ts
@@ -74,7 +74,7 @@ export const readConfig = async (options: CloudConfigOptions): Promise<ConfigObj
  */
 const readBootstrapConfig = async (options: CloudConfigOptions): Promise<ConfigObject> => {
 	// Load bootstrap.yml based on the profile name (like devEast or stagingEast)
-	let theBootstrapPath: string = options.bootstrapPath ? options.bootstrapPath : options.configPath;
+	const theBootstrapPath: string = options.bootstrapPath ? options.bootstrapPath : options.configPath;
 	const thisBootstrapConfig: ConfigObject = 
 		await readYamlAsDocument(`${theBootstrapPath}/bootstrap.yml`, options.activeProfiles);
 	thisBootstrapConfig.spring.cloud.config.profiles = options.activeProfiles;
@@ -91,7 +91,7 @@ const readBootstrapConfig = async (options: CloudConfigOptions): Promise<ConfigO
  */
 export const readApplicationConfig = async (appConfigPath: string, activeProfiles: string[]): Promise<ConfigObject> => {
 	const applicationConfig: ConfigObject = await readYamlAsDocument(appConfigPath + '/application.yml', activeProfiles);
-	let appConfigs: ConfigObject[] = [ applicationConfig ];
+	const appConfigs: ConfigObject[] = [ applicationConfig ];
 	activeProfiles.forEach(function(activeProfile) {
 		const profileSpecificYaml = 'application-' + activeProfile + '.yml';
 		const profileSpecificYamlPath = appConfigPath + '/' + profileSpecificYaml;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,0 +1,31 @@
+import * as joi from '@hapi/joi';
+
+export const CloudConfigOptionsSchema = joi.object().keys({
+    bootstrapPath: joi.string(),
+    configPath: joi.string().required(),
+    activeProfiles: joi.array().items(joi.string()).required(),
+    level: joi.string()
+});
+
+export const BootstrapConfigSchema = joi.object().keys({
+    spring: joi.object().required().keys({
+        cloud: joi.object().required().keys({
+            config: joi.object().required().keys({
+                enabled: joi.boolean().required(),
+                name: joi.string(),
+                endpoint: joi.string().uri().when(
+                    'enabled',
+                    {
+                        is: true,
+                        then: joi.required()
+                    }),
+                label: joi.string(),
+                rejectUnauthorized: joi.boolean(),
+                auth: joi.object().keys({
+                    user: joi.string().required(),
+                    pass: joi.string().required()
+                })
+            })
+        })
+    })
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -88,7 +88,7 @@ export const mergeProperties = (objects: object[]): object => {
  * @param {object} propertiesObject Object containing properties to be parsed
  * @returns {object} Object of deeply nested properties (not dot-separated)
  */
-export const parsePropertiesToObjects = (propertiesObject: object): object => {
+export const parsePropertiesToObjects = (propertiesObject: object | undefined): object => {
     var object: object = {};
     if (propertiesObject) {
         for (let thisPropertyName in propertiesObject) {

--- a/test/unit/SpringCloudConfig-test.ts
+++ b/test/unit/SpringCloudConfig-test.ts
@@ -1,56 +1,65 @@
 import { assert } from 'chai';
+import decache from 'decache';
 import * as sinon from 'sinon';
-import * as SpringCloudConfig from '../../src';
-import * as cloudConfigClient from "cloud-config-client";
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
 import { ConfigObject, CloudConfigOptions } from '../../src';
 
+chai.use(chaiAsPromised);
+chai.should();
+
 describe('SpringCloudConfig', function() {
+	const sandbox = sinon.createSandbox();
+	let cloudLoadStub;
+	let SpringCloudConfig;
+	let cloudConfigClient;
 
 	describe('#readApplicationConfig()', function() {
+
+		beforeEach(async function() {
+			SpringCloudConfig = require('../../src');
+			cloudConfigClient = require("cloud-config-client");
+		});
+
+		afterEach(async function() {
+			sandbox.restore();
+			decache('../../src');
+		});
 
 		it('should read application config without profile-specific yaml', async function() {
 			const appConfigPath: string = './test/fixtures/readAppConfig/singleAppYaml';
 			const activeProfiles: string[] = ['dev1'];
 
-			try {
-				const config: ConfigObject = await SpringCloudConfig.readApplicationConfig(appConfigPath, activeProfiles);
+			const readApplicationConfig: Promise<ConfigObject> = SpringCloudConfig.readApplicationConfig(appConfigPath, activeProfiles);
+			return readApplicationConfig.should.eventually.be.fulfilled.then((config: ConfigObject) => {
 				assert.deepEqual(config.testUrl, 'http://www.default.com');
 				assert.deepEqual(config.featureFlags.feature1, false);
 				assert.deepEqual(config.featureFlags.feature2, false);
-			}
-			catch (error) {
-				assert.fail('an error', 'success', error.message);
-			}
+			});
 		});
 
 		it('should read application config without profiles', async function() {
 			const appConfigPath: string = './test/fixtures/readAppConfig/multiAppYaml';
 			const activeProfiles: string[] = [];
 
-			try {
-				const config: ConfigObject = await SpringCloudConfig.readApplicationConfig(appConfigPath, activeProfiles);
+			const readApplicationConfig: Promise<ConfigObject> = SpringCloudConfig.readApplicationConfig(appConfigPath, activeProfiles);
+			return readApplicationConfig.should.eventually.be.fulfilled.then((config: ConfigObject) => {
 				assert.deepEqual(config.testUrl, 'http://www.default.com');
 				assert.deepEqual(config.featureFlags.feature1, false);
 				assert.deepEqual(config.featureFlags.feature2, false);
-			}
-			catch (error) {
-				assert.fail('an error', 'success', error.message);
-			}
+			});
 		});
 
 		it('should read multi application config with profiles', async function() {
 			const appConfigPath: string = './test/fixtures/readAppConfig/multiAppYaml';
 			const activeProfiles: string[] = ['dev2'];
 
-			try {
-				const config: ConfigObject = await SpringCloudConfig.readApplicationConfig(appConfigPath, activeProfiles);
+			const readApplicationConfig: Promise<ConfigObject> = SpringCloudConfig.readApplicationConfig(appConfigPath, activeProfiles);
+			return readApplicationConfig.should.eventually.be.fulfilled.then((config: ConfigObject) => {
 				assert.deepEqual(config.testUrl, 'http://www.dev2.com');
 				assert.deepEqual(config.featureFlags.feature1, true);
 				assert.deepEqual(config.featureFlags.feature2, false);
-			}
-			catch (error) {
-				assert.fail('an error', 'success', error.message);
-			}
+			});
 		});
 
 	});
@@ -58,11 +67,14 @@ describe('SpringCloudConfig', function() {
 	describe('#readCloudConfig()', function() {
 
 		beforeEach(async function() {
-			this.sandbox = sinon.sandbox.create();
+			SpringCloudConfig = require('../../src');
+			cloudConfigClient = require("cloud-config-client");
+			cloudLoadStub = sandbox.stub(cloudConfigClient, 'load');
 		});
 
 		afterEach(async function() {
-			this.sandbox.restore();
+			sandbox.restore();
+			decache('../../src');
 		});
 
 		it('should skip cloud config when not enabled', async function() {
@@ -70,19 +82,14 @@ describe('SpringCloudConfig', function() {
 				spring: {cloud: {config: {enabled: false}}}
 			};
 
-			try {
-				const config: ConfigObject = await SpringCloudConfig.readCloudConfig(bootstrapConfig);
+			const readCloudConfig: Promise<ConfigObject> = SpringCloudConfig.readCloudConfig(bootstrapConfig);
+			return readCloudConfig.should.eventually.be.fulfilled.then((config: ConfigObject) => {
 				assert.deepEqual(config, {});
-			}
-			catch (error) {
-				assert.fail('an error', 'success', error.message);
-			}
+			});
 		});
 
 		it('should skip cloud config if unreachable', async function() {
-			this.sandbox.stub(cloudConfigClient, 'load').returns(
-				Promise.reject(new Error('some error'))
-			);
+			cloudLoadStub.throws(new Error('some error'));
 			const bootstrapConfig: ConfigObject = {
 				spring: {cloud: {config: {
 					enabled: true,
@@ -91,13 +98,10 @@ describe('SpringCloudConfig', function() {
 				}}},
 			};
 
-			try {
-				const config: ConfigObject = await SpringCloudConfig.readCloudConfig(bootstrapConfig);
+			const readCloudConfig: Promise<ConfigObject> = SpringCloudConfig.readCloudConfig(bootstrapConfig);
+			return readCloudConfig.should.eventually.be.fulfilled.then((config: ConfigObject) => {
 				assert.deepEqual(config, {});
-			}
-			catch (error) {
-				assert.fail("Error", "Success", JSON.stringify(error.message));
-			}
+			});
 		});
 
 	});
@@ -105,41 +109,34 @@ describe('SpringCloudConfig', function() {
 	describe('#load()', function() {
 
 		beforeEach(async function() {
-			this.sandbox = sinon.sandbox.create();
+			SpringCloudConfig = require('../../src');
+			cloudConfigClient = require("cloud-config-client");
+			cloudLoadStub = sandbox.stub(cloudConfigClient, 'load');
 		});
 
 		afterEach(async function() {
-			this.sandbox.restore();
+			sandbox.restore();
+			decache('../../src');
 		});
 
 		it('should fail without app config path', async function() {
 			// @ts-ignore
 			const options: CloudConfigOptions = {
 				activeProfiles: []
-			}
+			};
 
-			try {
-				await SpringCloudConfig.load(options);
-				assert.fail('did not fail', 'a failure', 'this attempt should fail');
-			}
-			catch (error) {
-				assert.isOk('Success', 'Load failed as expected.');
-			}
+			const load: Promise<ConfigObject> = SpringCloudConfig.load(options);
+			return load.should.eventually.be.rejected;
 		});
 
 		it('should fail without activeProfiles', async function() {
 			// @ts-ignore
 			const options: CloudConfigOptions = {
 				configPath: './test/fixtures/load/config',
-			}
+			};
 
-			try {
-				await SpringCloudConfig.load(options);
-				assert.fail('did not fail', 'a failure', 'this attempt should fail');
-			}
-			catch (error) {
-				assert.isOk('Success', 'Load failed as expected.');
-			}
+			const load: Promise<ConfigObject> = SpringCloudConfig.load(options);
+			return load.should.eventually.be.rejected;
 		});
 
 		it('should fail with invalid bootstrap path', async function() {
@@ -147,15 +144,10 @@ describe('SpringCloudConfig', function() {
 				bootstrapPath: './badPath/commonConfig',
 				configPath: './test/fixtures/load/config',
 				activeProfiles: []
-			}
+			};
 
-			try {
-				await SpringCloudConfig.load(options);
-				assert.fail('did not fail', 'a failure', 'this attempt should fail');
-			}
-			catch (error) {
-				assert.isOk('Success', 'Load failed as expected.');
-			}
+			const load: Promise<ConfigObject> = SpringCloudConfig.load(options);
+			return load.should.eventually.be.rejected;
 		});
 
 		it('should fail with invalid app config path', async function() {
@@ -164,41 +156,44 @@ describe('SpringCloudConfig', function() {
 				configPath: './badPath/fixtures/load/config',
 				activeProfiles: [],
 				level: 'debug'
-			}
+			};
 
-			try {
-				await SpringCloudConfig.load(options);
-				assert.fail('did not fail', 'a failure', 'this attempt should fail');
-			}
-			catch (error) {
-				assert.isOk('Success', 'Load failed as expected.');
-			}
+			const load: Promise<ConfigObject> = SpringCloudConfig.load(options);
+			return load.should.eventually.be.rejected;
+		});
+
+		it('should fail with bad bootstrap config', async function() {
+			const options: CloudConfigOptions = {
+				bootstrapPath: './test/fixtures/load/badBootstrap',
+				configPath: './test/fixtures/load/config',
+				activeProfiles: []
+			};
+
+			const load: Promise<ConfigObject> = SpringCloudConfig.load(options);
+			return load.should.eventually.be.rejected;
 		});
 
 		it('should succeed with no bootstrap path and same config folder', async function() {
-			this.sandbox.stub(cloudConfigClient, 'load').returns(
+			cloudLoadStub.returns(
 				Promise.resolve({forEach(callback, aBoolValue) {}})
 			);
 			const options: CloudConfigOptions = {
 				configPath: './test/fixtures/load/configSameFolder',
 				activeProfiles: [],
 				level: 'debug'
-			}
+			};
 
-			try {
-				const config: ConfigObject = await SpringCloudConfig.load(options);
+			const load: Promise<ConfigObject> = SpringCloudConfig.load(options);
+			return load.should.eventually.be.fulfilled.then((config: ConfigObject) => {
 				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
 				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://localhost:8888');
 				assert.deepEqual(config.spring.cloud.config.label, 'master');
 				assert.deepEqual(config.testUrl, 'http://www.default.com');
-			}
-			catch (error) {
-				assert.fail("Error", "Success", JSON.stringify(error.message));
-			}
+			});
 		});
 
 		it('should load default configs with no profile', async function() {
-			this.sandbox.stub(cloudConfigClient, 'load').returns(
+			cloudLoadStub.returns(
 				Promise.resolve({forEach(callback, aBoolValue) {}})
 			);
 			const options: CloudConfigOptions = {
@@ -206,22 +201,19 @@ describe('SpringCloudConfig', function() {
 				configPath: './test/fixtures/load/config',
 				activeProfiles: [],
 				level: 'debug'
-			}
+			};
 
-			try {
-				const config: ConfigObject = await SpringCloudConfig.load(options);
+			const load: Promise<ConfigObject> = SpringCloudConfig.load(options);
+			return load.should.eventually.be.fulfilled.then((config: ConfigObject) => {
 				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
 				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://localhost:8888');
 				assert.deepEqual(config.spring.cloud.config.label, 'master');
 				assert.deepEqual(config.testUrl, 'http://www.default.com');
-			}
-			catch (error) {
-				assert.fail("Error", "Success", JSON.stringify(error.message));
-			}
+			});
 		});
 
 		it('should load default configs with app name override', async function() {
-			var cloudLoadStub = this.sandbox.stub(cloudConfigClient, 'load').returns(
+			cloudLoadStub.returns(
 				Promise.resolve({forEach(callback, aBoolValue) {}})
 			);
 			const options: CloudConfigOptions = {
@@ -229,21 +221,18 @@ describe('SpringCloudConfig', function() {
 				configPath: './test/fixtures/load/appNameConfig',
 				activeProfiles: [],
 				level: 'debug'
-			}
+			};
 
-			try {
-				const config: ConfigObject = await SpringCloudConfig.load(options);
+			const load: Promise<ConfigObject> = SpringCloudConfig.load(options);
+			return load.should.eventually.be.fulfilled.then((config: ConfigObject) => {
 				assert.deepEqual(config.spring.cloud.config.name, 'custom-app-name');
 				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://localhost:8888');
 				assert.deepEqual(config.spring.cloud.config.label, 'master');
-			}
-			catch (error) {
-				assert.fail("Error", "Success", JSON.stringify(error.message));
-			}
+			});
 		});
 		
 		it('should load dev configs with dev profile', async function() {
-			var cloudLoadStub = this.sandbox.stub(cloudConfigClient, 'load').returns(
+			cloudLoadStub.returns(
 				Promise.resolve({forEach(callback, aBoolValue) {}})
 			);
 			const options: CloudConfigOptions = {
@@ -251,26 +240,23 @@ describe('SpringCloudConfig', function() {
 				configPath: './test/fixtures/load/config',
 				activeProfiles: ['dev2'],
 				level: 'debug'
-			}
+			};
 
-			try {
-				const config: ConfigObject = await SpringCloudConfig.load(options);
+			const load: Promise<ConfigObject> = SpringCloudConfig.load(options);
+			return load.should.eventually.be.fulfilled.then((config: ConfigObject) => {
 				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
 				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://dev-config-server:8888');
 				assert.deepEqual(config.spring.cloud.config.label, 'master');
 				assert.deepEqual(config.testUrl, 'http://www.dev.com');
-			}
-			catch (error) {
-				assert.fail("Error", "Success", JSON.stringify(error.message));
-			}
+			});
 		});
 
 		it('should load cloud configs with default profile', async function() {
-			this.sandbox.stub(cloudConfigClient, 'load').returns(
+			cloudLoadStub.returns(
 				Promise.resolve({
 					forEach(callback, aBoolValue) {
 						callback('testUrl', 'http://www.default-local.com');
-						callback('featureFlags.feature1', false);
+						callback('featureFlags.feature1', true);
 						callback('featureFlags.feature2', false);
 					}
 				})
@@ -280,24 +266,21 @@ describe('SpringCloudConfig', function() {
 				configPath: './test/fixtures/load/config',
 				activeProfiles: ['default'],
 				level: 'debug'
-			}
+			};
 
-			try {
-				const config: ConfigObject = await SpringCloudConfig.load(options);
+			const load: Promise<ConfigObject> = SpringCloudConfig.load(options);
+			return load.should.eventually.be.fulfilled.then((config: ConfigObject) => {
 				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
 				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://localhost:8888');
 				assert.deepEqual(config.spring.cloud.config.label, 'master');
 				assert.deepEqual(config.testUrl, 'http://www.default-local.com');
-				assert.deepEqual(config.featureFlags.feature1, false);
+				assert.deepEqual(config.featureFlags.feature1, true);
 				assert.deepEqual(config.featureFlags.feature2, false);
-			}
-			catch (error) {
-				assert.fail("Error", "Success", JSON.stringify(error.message));
-			}
+			});
 		});
 
 		it('should load cloud configs with dev profile', async function() {
-			this.sandbox.stub(cloudConfigClient, 'load').returns(
+			cloudLoadStub.returns(
 				Promise.resolve({
 					forEach(callback, aBoolValue) {
 						callback('testUrl', 'http://www.dev-cloud.com');
@@ -311,35 +294,39 @@ describe('SpringCloudConfig', function() {
 				configPath: './test/fixtures/load/config',
 				activeProfiles: ['dev1'],
 				level: 'debug'
-			}
+			};
 
-			try {
-				const config: ConfigObject = await SpringCloudConfig.load(options);
+			const load: Promise<ConfigObject> = SpringCloudConfig.load(options);
+			return load.should.eventually.be.fulfilled.then((config: ConfigObject) => {
 				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
 				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://dev-config-server:8888');
 				assert.deepEqual(config.spring.cloud.config.label, 'master');
 				assert.deepEqual(config.testUrl, 'http://www.dev-cloud.com');
 				assert.deepEqual(config.featureFlags.feature1, true);
 				assert.deepEqual(config.featureFlags.feature2, false);
-			}
-			catch (error) {
-				assert.fail("Error", "Success", JSON.stringify(error.message));
-			}
+			});
 		});
 	});
 
 	describe('#instance()', function() {
 
 		beforeEach(async function() {
-			this.sandbox = sinon.sandbox.create();
+			SpringCloudConfig = require('../../src');
+			cloudConfigClient = require("cloud-config-client");
+			cloudLoadStub = sandbox.stub(cloudConfigClient, 'load');
 		});
 
 		afterEach(async function() {
-			this.sandbox.restore();
+			sandbox.restore();
+			decache('../../src');
+		});
+
+		it('should throw error if not loaded yet', async function() {
+			chai.expect(() => SpringCloudConfig.instance()).to.throw();
 		});
 
 		it('should return instance with defaults', async function() {
-			this.sandbox.stub(cloudConfigClient, 'load').returns(
+			cloudLoadStub.returns(
 				Promise.resolve({forEach(callback, aBoolValue) {}})
 			);
 			const options: CloudConfigOptions = {
@@ -347,18 +334,15 @@ describe('SpringCloudConfig', function() {
 				configPath: './test/fixtures/load/config',
 				activeProfiles: [],
 				level: 'debug'
-			}
+			};
 
-			try {
-				await SpringCloudConfig.load(options);
+			const load: Promise<ConfigObject> = SpringCloudConfig.load(options);
+			chai.expect(load).to.eventually.be.fulfilled.then(() => {
 				const theConfig: ConfigObject = SpringCloudConfig.instance();
 				assert.deepEqual(theConfig.spring.cloud.config.name, 'the-application-name');
 				assert.deepEqual(theConfig.spring.cloud.config.endpoint, 'http://localhost:8888');
 				assert.deepEqual(theConfig.testUrl, 'http://www.default.com');
-			}
-			catch (error) {
-				assert.fail("Error", "Success", JSON.stringify(error.message));
-			}
+			});
 		});
 		
 	});

--- a/test/unit/SpringCloudConfig-test.ts
+++ b/test/unit/SpringCloudConfig-test.ts
@@ -2,17 +2,18 @@ import { assert } from 'chai';
 import * as sinon from 'sinon';
 import * as SpringCloudConfig from '../../src';
 import * as cloudConfigClient from "cloud-config-client";
+import { ConfigObject, CloudConfigOptions } from '../../src';
 
 describe('SpringCloudConfig', function() {
 
 	describe('#readApplicationConfig()', function() {
 
 		it('should read application config without profile-specific yaml', async function() {
-			let appConfigPath = './test/fixtures/readAppConfig/singleAppYaml';
-			let activeProfiles = ['dev1'];
+			const appConfigPath: string = './test/fixtures/readAppConfig/singleAppYaml';
+			const activeProfiles: string[] = ['dev1'];
 
 			try {
-				const config = await SpringCloudConfig.readApplicationConfig(appConfigPath, activeProfiles);
+				const config: ConfigObject = await SpringCloudConfig.readApplicationConfig(appConfigPath, activeProfiles);
 				assert.deepEqual(config.testUrl, 'http://www.default.com');
 				assert.deepEqual(config.featureFlags.feature1, false);
 				assert.deepEqual(config.featureFlags.feature2, false);
@@ -23,11 +24,11 @@ describe('SpringCloudConfig', function() {
 		});
 
 		it('should read application config without profiles', async function() {
-			let appConfigPath = './test/fixtures/readAppConfig/multiAppYaml';
-			let activeProfiles = [];
+			const appConfigPath: string = './test/fixtures/readAppConfig/multiAppYaml';
+			const activeProfiles: string[] = [];
 
 			try {
-				const config = await SpringCloudConfig.readApplicationConfig(appConfigPath, activeProfiles);
+				const config: ConfigObject = await SpringCloudConfig.readApplicationConfig(appConfigPath, activeProfiles);
 				assert.deepEqual(config.testUrl, 'http://www.default.com');
 				assert.deepEqual(config.featureFlags.feature1, false);
 				assert.deepEqual(config.featureFlags.feature2, false);
@@ -38,11 +39,11 @@ describe('SpringCloudConfig', function() {
 		});
 
 		it('should read multi application config with profiles', async function() {
-			let appConfigPath = './test/fixtures/readAppConfig/multiAppYaml';
-			let activeProfiles = ['dev2'];
+			const appConfigPath: string = './test/fixtures/readAppConfig/multiAppYaml';
+			const activeProfiles: string[] = ['dev2'];
 
 			try {
-				const config = await SpringCloudConfig.readApplicationConfig(appConfigPath, activeProfiles);
+				const config: ConfigObject = await SpringCloudConfig.readApplicationConfig(appConfigPath, activeProfiles);
 				assert.deepEqual(config.testUrl, 'http://www.dev2.com');
 				assert.deepEqual(config.featureFlags.feature1, true);
 				assert.deepEqual(config.featureFlags.feature2, false);
@@ -65,12 +66,12 @@ describe('SpringCloudConfig', function() {
 		});
 
 		it('should skip cloud config when not enabled', async function() {
-			let bootstrapConfig = {
+			const bootstrapConfig: ConfigObject = {
 				spring: {cloud: {config: {enabled: false}}}
 			};
 
 			try {
-				const config = await SpringCloudConfig.readCloudConfig(bootstrapConfig);
+				const config: ConfigObject = await SpringCloudConfig.readCloudConfig(bootstrapConfig);
 				assert.deepEqual(config, {});
 			}
 			catch (error) {
@@ -82,7 +83,7 @@ describe('SpringCloudConfig', function() {
 			this.sandbox.stub(cloudConfigClient, 'load').returns(
 				Promise.reject(new Error('some error'))
 			);
-			let bootstrapConfig = {
+			const bootstrapConfig: ConfigObject = {
 				spring: {cloud: {config: {
 					enabled: true,
 					name: 'the-application-name',
@@ -91,7 +92,7 @@ describe('SpringCloudConfig', function() {
 			};
 
 			try {
-				const config = await SpringCloudConfig.readCloudConfig(bootstrapConfig);
+				const config: ConfigObject = await SpringCloudConfig.readCloudConfig(bootstrapConfig);
 				assert.deepEqual(config, {});
 			}
 			catch (error) {
@@ -112,13 +113,13 @@ describe('SpringCloudConfig', function() {
 		});
 
 		it('should fail without app config path', async function() {
-			let options = {
+			// @ts-ignore
+			const options: CloudConfigOptions = {
 				activeProfiles: []
 			}
 
 			try {
-				// @ts-ignore
-				const config = await SpringCloudConfig.load(options);
+				await SpringCloudConfig.load(options);
 				assert.fail('did not fail', 'a failure', 'this attempt should fail');
 			}
 			catch (error) {
@@ -127,13 +128,13 @@ describe('SpringCloudConfig', function() {
 		});
 
 		it('should fail without activeProfiles', async function() {
-			let options = {
+			// @ts-ignore
+			const options: CloudConfigOptions = {
 				configPath: './test/fixtures/load/config',
 			}
 
 			try {
-				// @ts-ignore
-				const config = await SpringCloudConfig.load(options);
+				await SpringCloudConfig.load(options);
 				assert.fail('did not fail', 'a failure', 'this attempt should fail');
 			}
 			catch (error) {
@@ -142,14 +143,14 @@ describe('SpringCloudConfig', function() {
 		});
 
 		it('should fail with invalid bootstrap path', async function() {
-			let options = {
+			const options: CloudConfigOptions = {
 				bootstrapPath: './badPath/commonConfig',
 				configPath: './test/fixtures/load/config',
 				activeProfiles: []
 			}
 
 			try {
-				const config = await SpringCloudConfig.load(options);
+				await SpringCloudConfig.load(options);
 				assert.fail('did not fail', 'a failure', 'this attempt should fail');
 			}
 			catch (error) {
@@ -158,7 +159,7 @@ describe('SpringCloudConfig', function() {
 		});
 
 		it('should fail with invalid app config path', async function() {
-			let options = {
+			const options: CloudConfigOptions = {
 				bootstrapPath: './test/fixtures/load/commonConfig',
 				configPath: './badPath/fixtures/load/config',
 				activeProfiles: [],
@@ -166,7 +167,7 @@ describe('SpringCloudConfig', function() {
 			}
 
 			try {
-				const config = await SpringCloudConfig.load(options);
+				await SpringCloudConfig.load(options);
 				assert.fail('did not fail', 'a failure', 'this attempt should fail');
 			}
 			catch (error) {
@@ -175,17 +176,17 @@ describe('SpringCloudConfig', function() {
 		});
 
 		it('should succeed with no bootstrap path and same config folder', async function() {
-			var cloudLoadStub = this.sandbox.stub(cloudConfigClient, 'load').returns(
+			this.sandbox.stub(cloudConfigClient, 'load').returns(
 				Promise.resolve({forEach(callback, aBoolValue) {}})
 			);
-			let options = {
+			const options: CloudConfigOptions = {
 				configPath: './test/fixtures/load/configSameFolder',
 				activeProfiles: [],
 				level: 'debug'
 			}
 
 			try {
-				const config = await SpringCloudConfig.load(options);
+				const config: ConfigObject = await SpringCloudConfig.load(options);
 				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
 				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://localhost:8888');
 				assert.deepEqual(config.spring.cloud.config.label, 'master');
@@ -197,10 +198,10 @@ describe('SpringCloudConfig', function() {
 		});
 
 		it('should load default configs with no profile', async function() {
-			var cloudLoadStub = this.sandbox.stub(cloudConfigClient, 'load').returns(
+			this.sandbox.stub(cloudConfigClient, 'load').returns(
 				Promise.resolve({forEach(callback, aBoolValue) {}})
 			);
-			let options = {
+			const options: CloudConfigOptions = {
 				bootstrapPath: './test/fixtures/load/commonConfig',
 				configPath: './test/fixtures/load/config',
 				activeProfiles: [],
@@ -208,7 +209,7 @@ describe('SpringCloudConfig', function() {
 			}
 
 			try {
-				const config = await SpringCloudConfig.load(options);
+				const config: ConfigObject = await SpringCloudConfig.load(options);
 				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
 				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://localhost:8888');
 				assert.deepEqual(config.spring.cloud.config.label, 'master');
@@ -223,7 +224,7 @@ describe('SpringCloudConfig', function() {
 			var cloudLoadStub = this.sandbox.stub(cloudConfigClient, 'load').returns(
 				Promise.resolve({forEach(callback, aBoolValue) {}})
 			);
-			let options = {
+			const options: CloudConfigOptions = {
 				bootstrapPath: './test/fixtures/load/commonConfig',
 				configPath: './test/fixtures/load/appNameConfig',
 				activeProfiles: [],
@@ -231,7 +232,7 @@ describe('SpringCloudConfig', function() {
 			}
 
 			try {
-				const config = await SpringCloudConfig.load(options);
+				const config: ConfigObject = await SpringCloudConfig.load(options);
 				assert.deepEqual(config.spring.cloud.config.name, 'custom-app-name');
 				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://localhost:8888');
 				assert.deepEqual(config.spring.cloud.config.label, 'master');
@@ -245,7 +246,7 @@ describe('SpringCloudConfig', function() {
 			var cloudLoadStub = this.sandbox.stub(cloudConfigClient, 'load').returns(
 				Promise.resolve({forEach(callback, aBoolValue) {}})
 			);
-			let options = {
+			const options: CloudConfigOptions = {
 				bootstrapPath: './test/fixtures/load/commonConfig',
 				configPath: './test/fixtures/load/config',
 				activeProfiles: ['dev2'],
@@ -253,7 +254,7 @@ describe('SpringCloudConfig', function() {
 			}
 
 			try {
-				const config = await SpringCloudConfig.load(options);
+				const config: ConfigObject = await SpringCloudConfig.load(options);
 				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
 				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://dev-config-server:8888');
 				assert.deepEqual(config.spring.cloud.config.label, 'master');
@@ -265,7 +266,7 @@ describe('SpringCloudConfig', function() {
 		});
 
 		it('should load cloud configs with default profile', async function() {
-			var cloudLoadStub = this.sandbox.stub(cloudConfigClient, 'load').returns(
+			this.sandbox.stub(cloudConfigClient, 'load').returns(
 				Promise.resolve({
 					forEach(callback, aBoolValue) {
 						callback('testUrl', 'http://www.default-local.com');
@@ -274,7 +275,7 @@ describe('SpringCloudConfig', function() {
 					}
 				})
 			);
-			let options = {
+			const options: CloudConfigOptions = {
 				bootstrapPath: './test/fixtures/load/commonConfig',
 				configPath: './test/fixtures/load/config',
 				activeProfiles: ['default'],
@@ -282,7 +283,7 @@ describe('SpringCloudConfig', function() {
 			}
 
 			try {
-				const config = await SpringCloudConfig.load(options);
+				const config: ConfigObject = await SpringCloudConfig.load(options);
 				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
 				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://localhost:8888');
 				assert.deepEqual(config.spring.cloud.config.label, 'master');
@@ -296,7 +297,7 @@ describe('SpringCloudConfig', function() {
 		});
 
 		it('should load cloud configs with dev profile', async function() {
-			var cloudLoadStub = this.sandbox.stub(cloudConfigClient, 'load').returns(
+			this.sandbox.stub(cloudConfigClient, 'load').returns(
 				Promise.resolve({
 					forEach(callback, aBoolValue) {
 						callback('testUrl', 'http://www.dev-cloud.com');
@@ -305,7 +306,7 @@ describe('SpringCloudConfig', function() {
 					}
 				})
 			);
-			let options = {
+			const options: CloudConfigOptions = {
 				bootstrapPath: './test/fixtures/load/commonConfig',
 				configPath: './test/fixtures/load/config',
 				activeProfiles: ['dev1'],
@@ -313,7 +314,7 @@ describe('SpringCloudConfig', function() {
 			}
 
 			try {
-				const config = await SpringCloudConfig.load(options);
+				const config: ConfigObject = await SpringCloudConfig.load(options);
 				assert.deepEqual(config.spring.cloud.config.name, 'the-application-name');
 				assert.deepEqual(config.spring.cloud.config.endpoint, 'http://dev-config-server:8888');
 				assert.deepEqual(config.spring.cloud.config.label, 'master');
@@ -338,10 +339,10 @@ describe('SpringCloudConfig', function() {
 		});
 
 		it('should return instance with defaults', async function() {
-			var cloudLoadStub = this.sandbox.stub(cloudConfigClient, 'load').returns(
+			this.sandbox.stub(cloudConfigClient, 'load').returns(
 				Promise.resolve({forEach(callback, aBoolValue) {}})
 			);
-			let options = {
+			const options: CloudConfigOptions = {
 				bootstrapPath: './test/fixtures/load/commonConfig',
 				configPath: './test/fixtures/load/config',
 				activeProfiles: [],
@@ -349,8 +350,8 @@ describe('SpringCloudConfig', function() {
 			}
 
 			try {
-				const config = await SpringCloudConfig.load(options);
-				let theConfig = SpringCloudConfig.instance();
+				await SpringCloudConfig.load(options);
+				const theConfig: ConfigObject = SpringCloudConfig.instance();
 				assert.deepEqual(theConfig.spring.cloud.config.name, 'the-application-name');
 				assert.deepEqual(theConfig.spring.cloud.config.endpoint, 'http://localhost:8888');
 				assert.deepEqual(theConfig.testUrl, 'http://www.default.com');

--- a/test/unit/SpringCloudConfig-test.ts
+++ b/test/unit/SpringCloudConfig-test.ts
@@ -56,6 +56,14 @@ describe('SpringCloudConfig', function() {
 
 	describe('#readCloudConfig()', function() {
 
+		beforeEach(async function() {
+			this.sandbox = sinon.sandbox.create();
+		});
+
+		afterEach(async function() {
+			this.sandbox.restore();
+		});
+
 		it('should skip cloud config when not enabled', async function() {
 			let bootstrapConfig = {
 				spring: {cloud: {config: {enabled: false}}}
@@ -71,6 +79,9 @@ describe('SpringCloudConfig', function() {
 		});
 
 		it('should skip cloud config if unreachable', async function() {
+			this.sandbox.stub(cloudConfigClient, 'load').returns(
+				Promise.reject(new Error('some error'))
+			);
 			let bootstrapConfig = {
 				spring: {cloud: {config: {
 					enabled: true,
@@ -134,8 +145,7 @@ describe('SpringCloudConfig', function() {
 			let options = {
 				bootstrapPath: './badPath/commonConfig',
 				configPath: './test/fixtures/load/config',
-				activeProfiles: [],
-				level: 'debug'
+				activeProfiles: []
 			}
 
 			try {

--- a/test/unit/logger-test.ts
+++ b/test/unit/logger-test.ts
@@ -4,6 +4,7 @@ import logger from '../../src/logger';
 describe('logger', function() {
 
 	describe("#config", function () {
+
 		it("should configure logger", function () {
             return new Promise((resolve, reject) => {
                 logger.info("");
@@ -12,6 +13,7 @@ describe('logger', function() {
                 resolve();
             });
         });
+
     });
 
 });

--- a/test/unit/utils-test.ts
+++ b/test/unit/utils-test.ts
@@ -6,64 +6,71 @@ import {
 	createObjectForProperty,
 	shouldUseDocument
 } from '../../src/utils';
+import { Document } from '../../src';
 
 describe('utils', function() {
 
 	describe("#readYaml()", function() {
+
 		it("should read test yaml without profiles", async function() {
-			const testProperties = readYaml('./test/fixtures/readYaml/test.yml')
+			const testProperties: Document = readYaml('./test/fixtures/readYaml/test.yml')
 			assert.deepEqual(testProperties['test.unit.testBool'], true);
 			assert.deepEqual(testProperties['test.unit.testString'], 'testing');
 			assert.deepEqual(testProperties['test.unit.testNumber'], 12345);
 		});
 
 		it("should read yaml and parse doc by profiles", async function() {
-			const testProperties = readYaml('./test/fixtures/readYaml/test-yaml-docs.yml', ['development'])
+			const testProperties: Document = readYaml('./test/fixtures/readYaml/test-yaml-docs.yml', ['development'])
 			assert.deepEqual(testProperties['test.unit.testBool'], true);
 			assert.deepEqual(testProperties['test.unit.testString'], 'testing again');
 			assert.deepEqual(testProperties['test.unit.testNumber'], 23456);
 		});
 
 		it("should read yaml and parse doc by profiles, even with multiple profiles", async function() {
-			const testProperties = readYaml('./test/fixtures/readYaml/test-yaml-with-profiles.yml', ['env1','env4'])
+			const testProperties: Document = readYaml('./test/fixtures/readYaml/test-yaml-with-profiles.yml', ['env1','env4'])
 			assert.deepEqual(testProperties['urlProperty'], 'http://www.testdomain-shared.com');
 			assert.deepEqual(testProperties['propertyGroup']['groupProperty'], false);
 		});
+
 	});
 
 	describe("#mergeProperties()", function() {
+
 		it("should merge properties between two files", async function() {
-			var obj1 = {
+			var obj1: object = {
 				'test.unit.testBool': true,
 				'test.unit.testString': 'testing',
 				'test.unit.testNumber': 12345
 			};
-			var obj2 = {
+			var obj2: object = {
 				'test.unit.testBool': true,
 				'test.unit.testString': 'testing again',
 				'test.unit.testNumber': 12345
 			};
 
-			var mergedProperties = mergeProperties([obj1, obj2]);
+			var mergedProperties: object = mergeProperties([obj1, obj2]);
 			assert.deepEqual(mergedProperties['test.unit.testBool'], true);
 			assert.deepEqual(mergedProperties['test.unit.testString'], 'testing again');
 			assert.deepEqual(mergedProperties['test.unit.testNumber'], 12345);
 		});
+
 	});
 
 	describe("#parsePropertiesToObjects()", function() {
+
 		it("should skip undefined object", async function() {
-			let mergedProperties;
-			let configObject = parsePropertiesToObjects(mergedProperties);
+			const mergedProperties: object | undefined = undefined;
+			const configObject: object = parsePropertiesToObjects(mergedProperties);
 			assert.deepEqual(configObject, {});
 		});
+
 		it("should parse dot-separated properties into JS object", async function() {
-			let mergedProperties = {
+			const mergedProperties: object = {
 				'test.unit.testBool': true,
 				'test.unit.testString': 'testing again',
 				'test.unit.testNumber': 12345
 			};
-			let expectedObject = {
+			const expectedObject: object = {
 				test: {
 					unit: {
 						testBool: true,
@@ -72,79 +79,82 @@ describe('utils', function() {
 					}
 				}
 			};
-			let configObject = parsePropertiesToObjects(mergedProperties);
+			const configObject: object = parsePropertiesToObjects(mergedProperties);
 			assert.deepEqual(configObject, expectedObject);
 		});
+
 	});
 
 	describe("#createObjectForProperty()", function() {
+
 		it("should construct a JS Object given a Boolean property's keys and value", async function() {
-			let expectedObjectFromBool = {
+			const expectedObjectFromBool: object = {
 				test: {
 					unit: {
 						testBool: true
 					}
 				}
 			};
-			let boolObject = createObjectForProperty(['test', 'unit', 'testBool'], true);
+			const boolObject: object = createObjectForProperty(['test', 'unit', 'testBool'], true);
 			assert.deepEqual(boolObject, expectedObjectFromBool);
 		});
 
 		it("should construct a JS Object given a String property's keys and value", async function() {
-			let expectedObjectFromString = {
+			const expectedObjectFromString: object = {
 				test: {
 					unit: {
 						testString: 'testing'
 					}
 				}
 			};
-			let stringObject = createObjectForProperty(['test', 'unit', 'testString'], 'testing');
+			const stringObject: object = createObjectForProperty(['test', 'unit', 'testString'], 'testing');
 			assert.deepEqual(stringObject, expectedObjectFromString);
 		});
 
 		it("should construct a JS Object given a Number property's keys and value", async function() {
-			let expectedObjectFromNumber = {
+			const expectedObjectFromNumber: object = {
 				test: {
 					unit: {
 						testNumber: 12345
 					}
 				}
 			};
-			let numberObject = createObjectForProperty(['test', 'unit', 'testNumber'], 12345);
+			const numberObject: object = createObjectForProperty(['test', 'unit', 'testNumber'], 12345);
 			assert.deepEqual(numberObject, expectedObjectFromNumber);
 		});
+
 	});
 
 	describe('#shouldUseDocument()', function() {
 
 		it('should not use undefined document', async function() {
-			let doc = undefined;
-			let activeProfiles = ['aProfile'];
+			const doc: Document | undefined = undefined;
+			const activeProfiles: string[] = ['aProfile'];
 			// @ts-ignore
 			assert.deepEqual(shouldUseDocument(doc, activeProfiles), false);
 		});
 
 		it('should not use document that has profiles, but no activeProfiles input', async function() {
-			let doc = {'profiles': 'aProfile'};
-			let activeProfiles;
+			const doc: Document = {'profiles': 'aProfile'};
+			const activeProfiles: string[] | undefined = undefined;
 			assert.deepEqual(shouldUseDocument(doc, activeProfiles), false);
 		});
 
 		it('should use document when doc.profiles is undefined', async function() {
-			let doc = {};
-			let activeProfiles = ['aProfile'];
+			const doc: Document = {};
+			const activeProfiles: string[] = ['aProfile'];
 			assert.deepEqual(shouldUseDocument(doc, activeProfiles), true);
 		});
 
 		it('should use document when activeProfiles matches a single doc.profiles', async function() {
-			let doc = {'profiles': 'devEast'};
-			let activeProfiles = ['devEast'];
+			const doc: Document = {'profiles': 'devEast'};
+			const activeProfiles: string[] = ['devEast'];
 			assert.deepEqual(shouldUseDocument(doc, activeProfiles), true);
 		});
 
 		it('should use document when one of activeProfiles matches one of doc.profiles', async function() {
-			let doc = {'profiles': 'devEast,devWest,stagingEast'};
-			let activeProfiles = ['devEast'];
+			const doc: Document = {'profiles': 'devEast,devWest,stagingEast'};
+			let activeProfiles: string[] = ['devEast'];
 			assert.deepEqual(shouldUseDocument(doc, activeProfiles), true);
 			activeProfiles = ['devWest'];
 			assert.deepEqual(shouldUseDocument(doc, activeProfiles), true);
@@ -153,8 +163,8 @@ describe('utils', function() {
 		});
 
 		it('should use document when multiple doc.profiles match active profiles', async function() {
-			let doc = {'profiles': 'devEast,devWest,stagingEast'};
-			let activeProfiles = ['devEast','devWest'];
+			const doc: Document = {'profiles': 'devEast,devWest,stagingEast'};
+			let activeProfiles: string[] = ['devEast','devWest'];
 			assert.deepEqual(shouldUseDocument(doc, activeProfiles), true);
 			activeProfiles = ['devWest','stagingEast'];
 			assert.deepEqual(shouldUseDocument(doc, activeProfiles), true);
@@ -163,16 +173,16 @@ describe('utils', function() {
 		});
 
 		it('should NOT use document when not operator used in doc.profiles for active profile', async function() {
-			let doc = {'profiles': 'devEast,!devWest,stagingEast'};
-			let activeProfiles = ['devEast','devWest'];
+			const doc: Document = {'profiles': 'devEast,!devWest,stagingEast'};
+			let activeProfiles: string[] = ['devEast','devWest'];
 			assert.deepEqual(shouldUseDocument(doc, activeProfiles), false);
 			activeProfiles = ['devWest','stagingEast'];
 			assert.deepEqual(shouldUseDocument(doc, activeProfiles), false);
 		});
 
 		it('should use document when not operator used in doc.profiles for non-active profile', async function() {
-			let doc = {'profiles': 'devEast,devWest,!stagingEast'};
-			let activeProfiles = ['devEast','devWest'];
+			let doc: Document = {'profiles': 'devEast,devWest,!stagingEast'};
+			let activeProfiles: string[] = ['devEast','devWest'];
 			assert.deepEqual(shouldUseDocument(doc, activeProfiles), true);
 			doc = {'profiles': 'devEast,!devWest,stagingEast'};
 			activeProfiles = ['devEast'];
@@ -181,5 +191,7 @@ describe('utils', function() {
 			activeProfiles = ['devWest','stagingEast'];
 			assert.deepEqual(shouldUseDocument(doc, activeProfiles), true);
 		});
+
 	});
+
 });


### PR DESCRIPTION
- Fix test for cloud config failure
- Typescript Types Cleanup
- Add JOI Schema Validation
- Update Sinon Sandbox Usage
- Decache SpringCloudConfig in Tests
- Use cha-as-promised in tests
- Bump Version to 4.2.0
- Updated README