### PR TITLE
Add fail-fast feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,11 @@ application-prod.yml
 
 ### Remote Property Sources
 
-If you enable the use of spring cloud config (via `spring.cloud.config.enabled: true`), the properties in `application.yml` will be overridden by any of the same properties defined in your remote sources. Keep in mind, however, any error encountered while reaching the remote property sources is currently ignored. Because of this, it is recommended that the properties defined in application.yml be kept up to date and represent the most current state of the application (as much as reasonably possible).
+If you enable the use of spring cloud config via the bootstrap property `spring.cloud.config.enabled: true`, the properties in `application.yml` will be overridden by any of the same properties defined in your remote sources. Keep in mind, however, any error encountered while reaching the remote property sources will be ignored, unless you set the bootstrap property `spring.cloud.config.fail-fast: true`. As a best practice, it is recommended that the properties defined in application.yml be kept up to date and represent the most current state of the application (as much as reasonably possible).
+
+#### Cloud Config Client Fail Fast
+
+If you need configuration loading to throw an error when it can't reach the cloud config server, set the bootstrap property `spring.cloud.config.fail-fast: true`.
 
 ## API
 ### `load` function
@@ -148,6 +152,7 @@ Option | Type | Description
 ------ | -------- | -----------
 spring.cloud.config | Object | The config options to use for fetching remote properties from a Spring Cloud Config Server.
 spring.cloud.config.enabled | boolean | Enable/disable the usage of remote properties via a Spring Cloud Config Server.
+spring.cloud.config.fail-fast | boolean | Enable/disable throwing an error when remote config retrieval fails.
 Properties Inherited from [cloud-config-client](https://www.npmjs.com/package/cloud-config-client) | | 
 spring.cloud.config.name | String | Optional - The application name to be used for reading remote properties. Alternatively, if not provided here, this must be specified in your application.yml.
 spring.cloud.config.endpoint | String | The url endpoint of the Spring Cloud Config Server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spring-cloud-config",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spring-cloud-config",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "NodeJS application configuration using similar style to Spring Config and using the Spring Cloud Config Server for remote property sources.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/SpringCloudConfig.ts
+++ b/src/SpringCloudConfig.ts
@@ -138,12 +138,13 @@ export const readCloudConfig = async (bootStrapConfig: ConfigObject): Promise<Co
 				cloudConfig = parsePropertiesToObjects(cloudConfig);
 			}
 			logger.debug("Cloud Config: " + JSON.stringify(cloudConfig));
-			return cloudConfig;
 		} catch (error) {
 			logger.error("Error reading cloud config: ", error);
-			return cloudConfig;
+			if (bootStrapConfig.spring.cloud.config['fail-fast'] === true) {
+				throw error;
+			}
 		};
-	} else {
-		return cloudConfig;
 	}
+	
+	return cloudConfig;
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -12,6 +12,7 @@ export const BootstrapConfigSchema = joi.object().keys({
         cloud: joi.object().required().keys({
             config: joi.object().required().keys({
                 enabled: joi.boolean().required(),
+                'fail-fast': joi.boolean(),
                 name: joi.string(),
                 endpoint: joi.string().uri().when(
                     'enabled',

--- a/test/fixtures/load/commonConfig/bootstrap.yml
+++ b/test/fixtures/load/commonConfig/bootstrap.yml
@@ -3,6 +3,7 @@ spring:
    cloud:
       config:
          enabled: true
+         fail-fast: true
          name: the-application-name
          endpoint: http://localhost:8888
          label: master

--- a/test/fixtures/load/configSameFolder/bootstrap.yml
+++ b/test/fixtures/load/configSameFolder/bootstrap.yml
@@ -3,6 +3,7 @@ spring:
    cloud:
       config:
          enabled: true
+         fail-fast: false
          name: the-application-name
          endpoint: http://localhost:8888
          label: master

--- a/test/unit/SpringCloudConfig-test.ts
+++ b/test/unit/SpringCloudConfig-test.ts
@@ -88,7 +88,7 @@ describe('SpringCloudConfig', function() {
 			});
 		});
 
-		it('should skip cloud config if unreachable', async function() {
+		it('should skip cloud config if unreachable (without fail-fast)', async function() {
 			cloudLoadStub.throws(new Error('some error'));
 			const bootstrapConfig: ConfigObject = {
 				spring: {cloud: {config: {
@@ -102,6 +102,21 @@ describe('SpringCloudConfig', function() {
 			return readCloudConfig.should.eventually.be.fulfilled.then((config: ConfigObject) => {
 				assert.deepEqual(config, {});
 			});
+		});
+
+		it('should throw error if cloud config errors and fail-fast is true', async function() {
+			cloudLoadStub.throws(new Error('some error'));
+			const bootstrapConfig: ConfigObject = {
+				spring: {cloud: {config: {
+					enabled: true,
+					'fail-fast': true,
+					name: 'the-application-name',
+					endpoint: 'http://somenonexistentdomain:8888'
+				}}},
+			};
+
+			const readCloudConfig: Promise<ConfigObject> = SpringCloudConfig.readCloudConfig(bootstrapConfig);
+			return readCloudConfig.should.eventually.be.rejected;
 		});
 
 	});


### PR DESCRIPTION
Closes #14 

Adds the fail-fast feature to bootstrap config.  If an error occurs while retrieving the remote property sources, and `spring.cloud.config.fail-fast` is set to `true`, the load function will throw the error instead of ignoring it.